### PR TITLE
Set `omnibus` flake input to git repo instead of local directory.

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -142,16 +142,17 @@
         "flops": "flops"
       },
       "locked": {
-        "dirtyRev": "c1597d8d7321229596e777064e21a35515986ceb-dirty",
-        "dirtyShortRev": "c1597d8-dirty",
-        "lastModified": 1709194343,
-        "narHash": "sha256-gSI6k2GW08kHmpoWfwA8VaKBBUAMMjVs8h4iQ5yKxgo=",
-        "type": "git",
-        "url": "file:///Users/guangtao/Dropbox/omnibus"
+        "lastModified": 1709886818,
+        "narHash": "sha256-VfdsRrqjhHFNpEWttztouZiO9wS7R266JR0z0jGbIps=",
+        "owner": "gtrunsec",
+        "repo": "omnibus",
+        "rev": "03ad7b524c89e281529e472d7ecaec614b7e1135",
+        "type": "github"
       },
       "original": {
-        "type": "git",
-        "url": "file:///Users/guangtao/Dropbox/omnibus"
+        "owner": "gtrunsec",
+        "repo": "omnibus",
+        "type": "github"
       }
     },
     "root": {

--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,6 @@
 {
   inputs = {
-    # omnibus.url = "github:gtrunsec/omnibus";
-    omnibus.url = "/Users/guangtao/Dropbox/omnibus";
+    omnibus.url = "github:gtrunsec/omnibus";
   };
 
   outputs =


### PR DESCRIPTION
The flake input for `omnibus` currently is set to a local path, instead of the actual repo.

I'm assuming this was to test using an  `omnibus` flake with changes that weren't available upstream.

Either way, commands like `nix flake show` fail, and consumption of the flake outputs in downstream flakes causes failures, even when setting the `omnibus` input to follow the upstream repo.

This PR sets the flake input to the upstream `omnibus` repository, and updates the `flake.lock`